### PR TITLE
chore: use crypto/rand replace math/rand

### DIFF
--- a/internal/database/dbutil/util.go
+++ b/internal/database/dbutil/util.go
@@ -1,17 +1,12 @@
 package dbutil
 
 import (
+	"crypto/rand"
 	"fmt"
-	"math/rand"
+	"math/big"
 	"strings"
 	"time"
 )
-
-var random *rand.Rand
-
-func init() {
-	random = rand.New(rand.NewSource(time.Now().UnixNano()))
-}
 
 type RowMap = map[string]interface{}
 
@@ -21,10 +16,18 @@ func TempTable(prefix string) string {
 
 var letterRunes = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
 
+func randInt(size int) int {
+	n, err := rand.Int(rand.Reader, big.NewInt(int64(size)))
+	if err != nil {
+		panic(err)
+	}
+	return int(n.Int64())
+}
+
 func RandString(n int) string {
 	b := make([]rune, n)
 	for i := range b {
-		b[i] = letterRunes[random.Intn(len(letterRunes))]
+		b[i] = letterRunes[randInt(len(letterRunes))]
 	}
 	return string(b)
 }

--- a/internal/database/online/test_impl/util.go
+++ b/internal/database/online/test_impl/util.go
@@ -2,16 +2,17 @@ package test_impl
 
 import (
 	"context"
-	"math/rand"
+	"crypto/rand"
+	"math/big"
 	"testing"
 	"time"
 
-	"github.com/oom-ai/oomstore/pkg/oomstore/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/oom-ai/oomstore/internal/database/dbutil"
 	"github.com/oom-ai/oomstore/internal/database/online"
+	"github.com/oom-ai/oomstore/pkg/oomstore/types"
 )
 
 type PrepareStoreFn func(*testing.T) (context.Context, online.Store)
@@ -97,7 +98,12 @@ func init() {
 
 	var data []types.ExportRecord
 	for i := 0; i < 100; i++ {
-		record := []interface{}{dbutil.RandString(10), rand.Float64()}
+		n, err := rand.Int(rand.Reader, big.NewInt(1000))
+		if err != nil {
+			panic(err)
+		}
+
+		record := []interface{}{dbutil.RandString(10), float64(n.Int64())}
 		data = append(data, types.ExportRecord{Record: record, Error: nil})
 	}
 	SampleMedium = Sample{


### PR DESCRIPTION
`math/rand` is much faster for applications that don’t need crypto-level or security-related random data generation. `crypto/rand` is suited for secure and crypto-ready usage, but it’s slower. But in most cases, `crypto/rand` is likely to be more suitable, unless the performance is critical but the application's security is not (which is rare).

It is highly recommended to use `crypto/rand` when needing to be secure with random numbers such as generating session ID in a web application.

relate: https://cwe.mitre.org/data/definitions/338.html